### PR TITLE
Handle npm-shrinkwrap.json with no dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ cp.exec(command, function (err, stdout, stderr) {
 
           return accum;
         }, [])
-      , clean = cleanDependencies(shrinkwrapped.dependencies, isProblematic(badDeps))
+      , clean = cleanDependencies(shrinkwrapped.dependencies || {}, isProblematic(badDeps))
       , finalObj = JSON.parse(JSON.stringify(shrinkwrapped));
 
     finalObj.dependencies = clean;


### PR DESCRIPTION
Fixes https://github.com/ansble/safe-shrinkwrap/issues/8