### PR TITLE
Don't run npm dedupe

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ if (shouldInstall) {
 }
 
 spinner.start();
-console.log(command);
+
 cp.exec(command, function (err, stdout, stderr) {
   if (err) {
     console.log(err);

--- a/index.js
+++ b/index.js
@@ -12,10 +12,8 @@ var path = require('path')
   })
 
   , shouldInstall = process.argv.indexOf('--no-install') === -1 && process.argv.indexOf('-ni') === -1
-  , command = shouldInstall ?
-      'npm cache clear && npm install && npm prune && npm shrinkwrap --dev' :
-      'npm prune && npm dedupe && npm shrinkwrap --dev'
-
+  , shouldDedupe = !(process.argv.indexOf('--no-dedupe') === -1 && process.argv.indexOf('-ndd') === -1)
+  , command = shouldInstall ? 'npm cache clear && npm install && ' : ''
   , isProblematic = function (badDeps) {
       return function (name) {
         return badDeps.indexOf(name) !== -1;
@@ -51,12 +49,18 @@ if (process.argv.indexOf('-h') >= 0 || process.argv.indexOf('--help') >= 0) {
   process.exit(0);
 }
 
+if (shouldDedupe) {
+  command = command + 'npm prune && npm dedupe && npm shrinkwrap --dev';
+} else {
+  command = command + 'npm prune && npm shrinkwrap --dev';
+}
+
 if (shouldInstall) {
   console.log('Clearing NPM cache and Proceeding to reinstall before we shrinkwrap');
 }
 
 spinner.start();
-
+console.log(command);
 cp.exec(command, function (err, stdout, stderr) {
   if (err) {
     console.log(err);

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var path = require('path')
   })
 
   , shouldInstall = process.argv.indexOf('--no-install') === -1 && process.argv.indexOf('-ni') === -1
-  , shouldDedupe = !(process.argv.indexOf('--no-dedupe') === -1 && process.argv.indexOf('-ndd') === -1)
+  , shouldDedupe = process.argv.indexOf('--no-dedupe') === -1 && process.argv.indexOf('-ndd') === -1
   , command = shouldInstall ? 'npm cache clear && npm install && ' : ''
   , isProblematic = function (badDeps) {
       return function (name) {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var path = require('path')
 
   , shouldInstall = process.argv.indexOf('--no-install') === -1 && process.argv.indexOf('-ni') === -1
   , command = shouldInstall ?
-      'npm cache clear && npm install && npm prune && npm dedupe && npm shrinkwrap --dev' :
+      'npm cache clear && npm install && npm prune && npm shrinkwrap --dev' :
       'npm prune && npm dedupe && npm shrinkwrap --dev'
 
   , isProblematic = function (badDeps) {


### PR DESCRIPTION
While trying to use `safe-shrinkwrap` on a project, I ran into issues where `fsevents` ended up with a mix of extraneous and missing dependencies as a result of `npm dedupe`. It seems very similar to the issues described in https://github.com/npm/npm/issues/6933. I tried in multiple versions of node, including 6.x.x and 7.x.x and reproduced this in OS X (it works in Windows though). The change in this PR resolved the issue for me.

For an easy repro, clone https://github.com/paulmillr/chokidar in OS X and run `safe-shrinkwrap` against it.

I'm curious if there are any alternatives to this approach.

Also, thanks for this tool, it's great :)